### PR TITLE
BUILD-5603 fix pre-commit issues in pre-commit workflow template

### DIFF
--- a/{{cookiecutter.repository_name}}/.github/workflows/pre-commit.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/pre-commit.yml
@@ -22,4 +22,5 @@ jobs:
         with:
           extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
           ignore-failure: ${{ env.IGNORE_FAILURE }}
-  {% endraw %}
+
+{% endraw %}

--- a/{{cookiecutter.repository_name}}/.github/workflows/pre-commit.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/pre-commit.yml
@@ -2,25 +2,16 @@
 {% raw %}
 on:
   pull_request:
-  merge_group:
 
 jobs:
   pre-commit:
     name: "pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - name: "Do not ignore pre-commit failures on PRs"
-        if: github.event_name != 'merge_group'
-        run: echo "IGNORE_FAILURE=false" >> $GITHUB_ENV
-        shell: bash
-      - name: "Ignore pre-commit failures on gh merge queues"
-        if: github.event_name == 'merge_group'
-        run: echo "IGNORE_FAILURE=true" >> $GITHUB_ENV
-        shell: bash
-
-      - uses: SonarSource/gh-action_pre-commit@dfd365240ac6bc71b9912ff8f231a7543214f1b2 # 0.0.2
+      - uses: SonarSource/gh-action_pre-commit@f04ea4aa921469a3f203f82f8965d3a308f59d91 # 0.0.7
         with:
-          extra-args: --from-ref=origin/${{ github.event.pull_request.base.ref }} --to-ref=${{ github.event.pull_request.head.sha }}
-          ignore-failure: ${{ env.IGNORE_FAILURE }}
+          extra-args: >
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}
 
 {% endraw %}


### PR DESCRIPTION
## Changes

- [x] Add missing empty line to `.github/workflows/pre-commit.yml` (That way it pass pre-commit fix end of files)

### Misc

- [x] Update gh-action_pre-commit to `0.0.7`
      That way we avoid one Renovate PR to newly created repositories
- [x] Simplify the workflow; most repositories are not using merge queues and do not need such complex workflows for pre-commit. (improve maintainability)