### PR TITLE
BUILD-8605 Include mise version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up Mise
-        uses: jdx/mise-action@df7d3c87bfdd3fe229201cd1a01b21ad31d48b95
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
       - name: Cache Poetry dependencies
         uses: SonarSource/ci-github-actions/cache@master
         with:


### PR DESCRIPTION
This PR updates `jdx/mise-action` to a pinned version and configures the `mise` version to `2025.7.12`.