### PR TITLE
BUILD-10204: Upgrade urllib3 for CVEs reported by SQ

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1074,14 +1074,14 @@ reference = "repox"
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main", "test"]
 files = [
-    {file = "urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc"},
-    {file = "urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760"},
+    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
+    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ priority = "primary"
 [tool.poetry.dependencies]
 python = "^3.10"
 pytest-cookies = "^0.7.0"
+urllib3 = "^2.6.3"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.0.0"


### PR DESCRIPTION
Upgrades urllib3 from `2.5.0` to `2.6.3` to resolve the CVEs [reported in SonarQube](https://next.sonarqube.com/sonarqube/dependency-risks?id=SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d&riskStatuses=OPEN%2CCONFIRM). I have validated the new SHAs with [what exists in Repox for 2.6.3 here](https://repox.jfrog.io/ui/repos/tree/General/pypi-remote-cache/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl?clearFilter=true).