### PR TITLE
BUILD-10204: Upgrade werkzeug for CVEs reported by SQ

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1097,14 +1097,14 @@ reference = "repox"
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.5"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.9"
 groups = ["test"]
 files = [
-    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
-    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+    {file = "werkzeug-3.1.5-py3-none-any.whl", hash = "sha256:5111e36e91086ece91f93268bb39b4a35c1e6f1feac762c9c822ded0a4e322dc"},
+    {file = "werkzeug-3.1.5.tar.gz", hash = "sha256:6a548b0e88955dd07ccb25539d7d0cc97417ee9e179677d22c7041c8f078ce67"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pytest-httpserver = "^1.0.8"
 coverage = {extras = ["toml"], version = "^7.0.0"}
 pytest-mock = "^3.11.1"
 cookiecutter = "^2.6.0"
+werkzeug = "^3.1.5"
 
 [tool.pytest.ini_options]
 log_cli = true


### PR DESCRIPTION
Upgrades werkzeug from `3.1.3` to `3.1.5` to resolve the CVEs [reported in SonarQube](https://next.sonarqube.com/sonarqube/dependency-risks?severities=LOW%2CMEDIUM%2CHIGH%2CBLOCKER&types=VULNERABILITY&id=SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d&riskStatuses=OPEN%2CCONFIRM). I have validated the new SHAs with [what exists in Repox for 3.1.5 here](https://repox.jfrog.io/ui/repos/tree/General/pypi-remote-cache/ad/e4/8d97cca767bcc1be76d16fb76951608305561c6e056811587f36cb1316a8/werkzeug-3.1.5-py3-none-any.whl?clearFilter=true).