### PR TITLE
BUILD-10204: Adds unified-dogfooding to repo

### DIFF
--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,0 +1,24 @@
+name: Unified Dogfooding scans
+on:
+  schedule:
+    - cron: "0 4 * * *" # Run the workflow every day at 04:00 UTC
+  workflow_dispatch:
+
+jobs:
+  unified-platform-dogfooding:
+    runs-on: github-ubuntu-latest-s
+    name: Unified Platform Dogfooding
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Run IRIS Analysis
+        uses: SonarSource/unified-dogfooding-actions/run-iris@v1
+        with:
+          primary_project_key: SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d
+          primary_platform: SQC-EU
+          shadow1_project_key: SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d
+          shadow1_platform: Next
+          shadow2_project_key: SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d
+          shadow2_platform: SQC-US


### PR DESCRIPTION
- Adds the `unified-dogfooding` workflow to the repo
- Uses the [key from the sonar-project.properties file](https://github.com/SonarSource/cookiecutter-sonar/blob/master/sonar-project.properties), `SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d` as the `primary_project_key` on SQC US, SQC EU, and SQ Next.
  - **Reviewer, please let me know if this is correct**