### PR TITLE
chore: upgrade gh-action_release to v7

### DIFF
--- a/{{cookiecutter.repository_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/release.yml
@@ -16,4 +16,4 @@ jobs:
       contents: write
     uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
-      version: ${{ inputs.version }}
+      version: ${{ '{{' }} inputs.version {{ '}}' }}

--- a/{{cookiecutter.repository_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/release.yml
@@ -1,16 +1,19 @@
 ---
 name: Release
+# yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
-
-env:
-  PYTHONUNBUFFERED: 1
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@f610ee562da0eb743c378afb819f6bfb39e812cf # 6.2.1
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
+    with:
+      version: ${{ inputs.version }}


### PR DESCRIPTION
Part of BUILD-11249.

## Changes
- Migrate trigger from `release: published` to `workflow_dispatch` with `version` input
- Upgrade `gh-action_release` reference to `@v7`

## Breaking changes addressed
- v7 requires a `version` input (no longer inferred from GitHub release tag)
- v7 uses `workflow_dispatch` instead of `release: published` trigger