### PR TITLE
BUILD-11786 Fix failing SonarQube quality gate (coverage report)

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d
 sonar.python.version=3.10
+sonar.python.coverage.reportPaths=coverage.xml
 
 # Exclude test files and post-generation hooks from coverage analysis
 # Post-generation hooks run in subprocess during cookiecutter execution and can't be tracked by coverage tools

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=SonarSource_cookiecutter-sonar_1057b558-cc05-44b4-b026-6a753112a87d
 sonar.python.version=3.10
-sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.coverage.reportPaths=coverage.xml,build/coverage.xml
 
 # Exclude test files and post-generation hooks from coverage analysis
 # Post-generation hooks run in subprocess during cookiecutter execution and can't be tracked by coverage tools


### PR DESCRIPTION
## Summary
- Add `sonar.python.coverage.reportPaths=coverage.xml` so the pytest coverage report produced in CI is sent to SonarQube Next

## Context
Master quality gate is **failed** because coverage is reported as *not found* even though the build workflow runs `pytest --cov-report=xml:coverage.xml`.

## Test plan
- [ ] Build workflow passes on this PR
- [ ] SonarQube scan picks up coverage and quality gate passes on master after merge