### PR TITLE
BUILD-11976 Use sonar-xs runner for public repos in cookiecutter templates

### DIFF
--- a/{{cookiecutter.repository_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/build.yml
@@ -15,14 +15,9 @@ concurrency:
 
 jobs:
   build:
-    # TODO: Choose the appropriate runner for your repository
     # For guidance on runner selection, visit:
     # https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platform/pages/3694231566/GitHub+Actions+Runner+-+GitHub
-    {% if cookiecutter.repository_visibility == "public" -%}
-    runs-on: github-ubuntu-latest-s  # Required for public repositories
-    {% else -%}
-    runs-on: sonar-xs  # Recommended for private/internal repositories
-    {% endif -%}
+    runs-on: sonar-xs
     name: Build
     permissions:
       id-token: write

--- a/{{cookiecutter.repository_name}}/.github/workflows/pr-cleanup.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/pr-cleanup.yml
@@ -5,14 +5,7 @@ on:
 
 jobs:
   cleanup:
-    # Runner selection based on repository visibility:
-    # - Private/internal repositories: sonar-xs
-    # - Public repositories: github-ubuntu-latest-s
-    {% if cookiecutter.repository_visibility == "public" -%}
-    runs-on: github-ubuntu-latest-s
-    {% else -%}
     runs-on: sonar-xs
-    {% endif -%}
     name: Cleanup
     permissions:
       actions: write

--- a/{{cookiecutter.repository_name}}/.github/workflows/unified-dogfooding.yml
+++ b/{{cookiecutter.repository_name}}/.github/workflows/unified-dogfooding.yml
@@ -27,14 +27,7 @@ on:
 
 jobs:
   build:
-    # Runner selection based on repository visibility:
-    # - Private/internal repositories: sonar-xs
-    # - Public repositories: github-ubuntu-latest-s
-    {% if cookiecutter.repository_visibility == "public" -%}
-    runs-on: github-ubuntu-latest-s
-    {% else -%}
     runs-on: sonar-xs
-    {% endif -%}
     name: Build
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary
- Update cookiecutter workflow templates so public repositories use `sonar-xs` instead of `github-ubuntu-latest-s`
- Remove the visibility-based runner conditional now that both public and private/internal repos use `sonar-xs`

## Context
Slack ask from Jayadeep: public-repo runner label in the cookiecutter template should be `sonar-xs`.

Jira: [BUILD-11976](https://sonarsource.atlassian.net/browse/BUILD-11976)

## Test plan
- [ ] Review rendered `build.yml`, `pr-cleanup.yml`, and `unified-dogfooding.yml` for a public bake
- [ ] Confirm private/internal bake still uses `sonar-xs`
- [ ] CI passes on this PR

[BUILD-11976]: https://sonarsource.atlassian.net/browse/BUILD-11976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ